### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,29 @@
 
   MVC的臃肿让写代码变的不快乐,所以想尝试用MVP来写个DEMO,从实践中学习.
 
-###下载
+### 下载
    链接:<br/>http://fir.im/sunoath<br/>
    
-###截图
+### 截图
 ![image](https://github.com/Rtsunoath/Sunoath/blob/master/Img/1.png)
 ![image](https://github.com/Rtsunoath/Sunoath/blob/master/Img/3.png)
 ![image](https://github.com/Rtsunoath/Sunoath/blob/master/Img/4.png)
 ![image](https://github.com/Rtsunoath/Sunoath/blob/master/Img/5.png)
 
-###参考
+### 参考
 [SimpleNews](https://github.com/liuling07/SimpleNews)
 [MeiZhi](https://github.com/drakeet/Meizhi)
 
-###知识点
+### 知识点
 浅谈Android开发中的MVP模式<br/>http://www.jcodecraeer.com/a/anzhuokaifa/androidkaifa/2016/0225/3994.html
 </br>
 Retrofit <br/>http://www.jcodecraeer.com/a/anzhuokaifa/androidkaifa/2015/0915/3460.html</br>
 ButterKnife<br/>https://github.com/JakeWharton/butterknife</br>
 
-##关于我
+## 关于我
 [@RtSunoath](http://weibo.com/Rtsunoath).
 
-###License
+### License
 MIT
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
